### PR TITLE
Invchar

### DIFF
--- a/compiler/CCodegen.ob
+++ b/compiler/CCodegen.ob
@@ -28,6 +28,7 @@ VAR
   addBoundsChecks: BOOLEAN;
   genCPlusPlus:    BOOLEAN;
   GenExpr:         PROCEDURE (l: Lex.Lexer; e: AST.Expr);
+  cIntegerSize:    ARRAY 16 OF CHAR;
 
 PROCEDURE GenStr(s: ARRAY OF CHAR);
 BEGIN
@@ -115,7 +116,7 @@ BEGIN
   IF (t.decl = NIL) OR skipDecl THEN
     CASE t.kind OF
       AST.typeInteger:
-        GenStr("int ");
+        GenStr(cIntegerSize);
         GenQName(l, name);
     | AST.typeReal:
         GenStr("OBERON_REAL ");
@@ -1247,6 +1248,7 @@ BEGIN
   GenExpr := GenExpr0;
   addBoundsChecks := FALSE;
   genCPlusPlus := FALSE;
+  cIntegerSize := "int64_t ";   (* was: "int "  (1 space character needed) *)
   indent := 0;
   innerProcCount := 0
 END CCodegen.

--- a/compiler/Lex.ob
+++ b/compiler/Lex.ob
@@ -718,8 +718,8 @@ END ScanComment;
 
 PROCEDURE NextToken*(VAR l: Lexer);
 BEGIN
-  l.t.kind := tINVALIDCHAR;
   REPEAT
+    l.t.kind := tINVALIDCHAR;
     CASE l.buf[l.pos] OF
       0X: l.t.kind := tEOF;
       (* space, newline, carriage return, newline, tab, vertical tab *)

--- a/compiler/Lex.ob
+++ b/compiler/Lex.ob
@@ -1020,5 +1020,5 @@ END RunTests;
 BEGIN
   InitTokenNames;
   fatal := TRUE;
-  ignoreKeywordCase := TRUE;
+  ignoreKeywordCase := FALSE;
 END Lex.

--- a/compiler/runtime.c
+++ b/compiler/runtime.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 #define ASSERT assert
 #define oberon_abs(x) ((x) < 0) ? -(x) : (x)


### PR DESCRIPTION
Compiler does not report invalid characters, when following a whitespace or comment character but spins for ever.
A sometimes difficult to find error. For instance 'A' from Oberon-2 habits instead of Oberon-7 "A".

This commit is intended to fix that.