### PR TITLE
change some overlooked keywords from lower case to upper case

### DIFF
--- a/tests/M6502.ob
+++ b/tests/M6502.ob
@@ -224,7 +224,7 @@ BEGIN
 	m := CEA(p, mode);
 	IF decimaL IN p.flags THEN
 		r := BCDtoBIN(p.a) + BCDtoBIN(m);
-		IF carrY in p.flags THEN INC(r) END;
+		IF carrY IN p.flags THEN INC(r) END;
 		SetC(p, r > 99);
 		SetNZ(p, r);
 		p.a := BINtoBCD(r)

--- a/tests/Sound.ob
+++ b/tests/Sound.ob
@@ -78,21 +78,21 @@ BEGIN
    *)
 
   (* Three seconds at 8k *)
-  FOR t := 0 to 24000 DO
+  FOR t := 0 TO 24000 DO
     x := Frac(FLT(t) * A4 / 8000.0);
     Out.Char(CHR(Scale(SawtoothWave(x))))
   END;
-  FOR t := 0 to 4000 DO
+  FOR t := 0 TO 4000 DO
     Out.Char(CHR(128))
   END;
-  FOR t := 0 to 24000 DO
+  FOR t := 0 TO 24000 DO
     x := Frac(FLT(t) * A4 / 8000.0);
     Out.Char(CHR(Scale(SquareWave(x))))
   END;
-  FOR t := 0 to 4000 DO
+  FOR t := 0 TO 4000 DO
     Out.Char(CHR(128))
   END;
-  FOR t := 0 to 24000 DO
+  FOR t := 0 TO 24000 DO
     x := Frac(FLT(t) * A4 / 8000.0);
     Out.Char(CHR(Scale(TriangleWave(x))))
   END
@@ -102,11 +102,11 @@ PROCEDURE MajorScale;
   PROCEDURE Note(freq: REAL);
   VAR t: INTEGER; x: REAL;
   BEGIN
-    FOR t := 0 to 4000 DO
+    FOR t := 0 TO 4000 DO
       x := Frac(FLT(t) * freq / 8000.0);
       Out.Char(CHR(Scale(SquareWave(x))))
     END;
-    FOR t := 0 to 1000 DO
+    FOR t := 0 TO 1000 DO
       Out.Char(CHR(128))
     END
   END Note;

--- a/tests/Sudoku.ob
+++ b/tests/Sudoku.ob
@@ -125,7 +125,7 @@ BEGIN
   FOR i := 0 TO 2 DO
     FOR j := 0 TO 2 DO
       b := board[start + i*9 + j];
-      IF (b # 0) & (b in used) THEN
+      IF (b # 0) & (b IN used) THEN
         RETURN FALSE
       ELSE
         used := used + {b}
@@ -156,7 +156,7 @@ VAR
 BEGIN
   a := 0;
   FOR i := 1 TO 9 DO
-    IF i in s THEN INC(a) END
+    IF i IN s THEN INC(a) END
   END
   RETURN a
 END NumberOfOneBits;
@@ -180,7 +180,7 @@ BEGIN
   elt := -1;
   WHILE n > 0 DO
     INC(elt);
-    IF elt in s THEN DEC(n) END;
+    IF elt IN s THEN DEC(n) END;
   END
   RETURN elt
 END NthSetBit;


### PR DESCRIPTION
On my way to remove Python dependency (perr.py) and change compiler default to insist on upper case keywords
i found a few forgotten lower case keywords and edited them to upper case.

Regards!